### PR TITLE
Set the defaultView as a property on the DisplayControl's dataSelection

### DIFF
--- a/src/ucar/unidata/data/DataSelection.java
+++ b/src/ucar/unidata/data/DataSelection.java
@@ -78,6 +78,9 @@ public class DataSelection {
     /** region option */
     public final static String PROP_USESELECTEDAREA = "Use_Selected_Area";
     
+    /** view manager - used for time/region matching */
+    public final static String PROP_DEFAULTVIEW = "Default_View";
+    
     /** logging category */
     static ucar.unidata.util.LogUtil.LogCategory log_ =
         ucar.unidata.util.LogUtil.getLogInstance(

--- a/src/ucar/unidata/data/DataSourceImpl.java
+++ b/src/ucar/unidata/data/DataSourceImpl.java
@@ -33,6 +33,7 @@ import ucar.unidata.geoloc.ProjectionImpl;
 import ucar.unidata.idv.DisplayControl;
 import ucar.unidata.idv.IntegratedDataViewer;
 import ucar.unidata.idv.MapViewManager;
+import ucar.unidata.idv.ViewDescriptor;
 import ucar.unidata.idv.ViewManager;
 import ucar.unidata.idv.chooser.IdvChooser;
 import ucar.unidata.idv.chooser.IdvChooserManager;
@@ -2149,7 +2150,15 @@ public class DataSourceImpl extends SharableImpl implements DataSource,
             }
             if (useTDT && (timeDriverTimes == null)) {
                 //check view manager
-                ViewManager vm  = getIdv().getViewManager();
+                ViewManager vm  = null;
+                String vmName = givenDataSelection.getProperty(
+                        DataSelection.PROP_DEFAULTVIEW, null);
+                if (vmName !=null) {
+                    vm = getIdv().getViewManager(new ViewDescriptor(vmName), false, null);
+                }
+                if (vm == null) {
+                    vm = getIdv().getViewManager();
+                }
                 List        tdt = null;
                 try {
                     tdt = vm.getTimeDriverTimes();

--- a/src/ucar/unidata/idv/control/DisplayControlImpl.java
+++ b/src/ucar/unidata/idv/control/DisplayControlImpl.java
@@ -3722,6 +3722,9 @@ public abstract class DisplayControlImpl extends DisplayControlBase implements D
         if ( !getIdv().getUseTimeDriver()) {
             return dataSelection;
         }
+        if (defaultView != null) {
+            dataSelection.putProperty(DataSelection.PROP_DEFAULTVIEW, defaultView);
+        }
         if (getIsTimeDriver() || !getUsesTimeDriver()) {
             if ( !getUsesTimeDriver()) {
                 dataSelection.setTheTimeDriverTimes(null);


### PR DESCRIPTION
so that data requests can find the correct time driver.  Might need to
make sure we are getting the right view for region matching also.
